### PR TITLE
#9: Smash all build-level uses of name 'detection' to 'detector'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(detection)
+project(detector)
 
 include(cmake/turn_on_warnings.cmake)
 
@@ -15,34 +15,34 @@ file(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/*.h
 )
 
-set(DETECTION_LIBRARY detector)
-set(DETECTION_LIBRARY_NS vt::lib::detector)
+set(DETECTOR_LIBRARY detector)
+set(DETECTOR_LIBRARY_NS vt::lib::detector)
 
 add_custom_target(detector_examples)
 add_subdirectory(examples)
 
 install(FILES ${HEADER_FILES} DESTINATION include)
 
-add_library(${DETECTION_LIBRARY} INTERFACE)
-add_library(${DETECTION_LIBRARY_NS} ALIAS ${DETECTION_LIBRARY})
+add_library(${DETECTOR_LIBRARY} INTERFACE)
+add_library(${DETECTOR_LIBRARY_NS} ALIAS ${DETECTOR_LIBRARY})
 
-target_compile_features(${DETECTION_LIBRARY} INTERFACE cxx_std_14)
+target_compile_features(${DETECTOR_LIBRARY} INTERFACE cxx_std_14)
 target_compile_features(
-  ${DETECTION_LIBRARY} INTERFACE
+  ${DETECTOR_LIBRARY} INTERFACE
   cxx_variadic_templates
   cxx_auto_type
   cxx_constexpr
 )
 
 target_include_directories(
-  ${DETECTION_LIBRARY} INTERFACE
+  ${DETECTOR_LIBRARY} INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   $<INSTALL_INTERFACE:include>
 )
 
 install(
-  TARGETS                 ${DETECTION_LIBRARY}
-  EXPORT                  ${DETECTION_LIBRARY}
+  TARGETS                 ${DETECTOR_LIBRARY}
+  EXPORT                  ${DETECTOR_LIBRARY}
   LIBRARY DESTINATION     lib
   ARCHIVE DESTINATION     lib
   RUNTIME DESTINATION     bin
@@ -50,7 +50,7 @@ install(
 )
 
 install(
-  EXPORT                  ${DETECTION_LIBRARY}
+  EXPORT                  ${DETECTOR_LIBRARY}
   DESTINATION             cmake
   NAMESPACE               vt::lib::
   FILE                    "detectorTargets.cmake"
@@ -68,7 +68,7 @@ install(
 )
 
 export(
-  TARGETS                   ${DETECTION_LIBRARY}
-  FILE                      "detectionTargets.cmake"
+  TARGETS                   ${DETECTOR_LIBRARY}
+  FILE                      "detectorTargets.cmake"
   NAMESPACE                 vt::lib::
 )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -32,7 +32,7 @@ foreach(EXAMPLE_FULL ${PROJECT_EXAMPLES})
 
   add_dependencies(detector_examples ${EXAMPLE})
 
-  target_link_libraries(${EXAMPLE} ${DETECTION_LIBRARY})
+  target_link_libraries(${EXAMPLE} ${DETECTOR_LIBRARY})
 
   add_test_for_example(
     detector:${EXAMPLE}


### PR DESCRIPTION
Fixes #9